### PR TITLE
Small front-end changes

### DIFF
--- a/app/src/components/Canvas/canvas.js
+++ b/app/src/components/Canvas/canvas.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useMemo } from 'react'
 import { useInterval } from 'ahooks'
 import { Row, Col } from 'react-bootstrap'
 import $ from 'jquery'
@@ -9,7 +9,7 @@ import SidePanel from '../SidePanel/sidePanel'
 import CoordinateViewer from './coordinateViewer'
 import ToggleOwnedSquares from './toggleOwnedSquares'
 import { BlockchainContext } from '../stateProvider'
-import { CoordinateContext } from '../../context/CoordinateContext'
+import { CoordinateContext, HighlightContext } from '../canvasContextProvider'
 
 const gridLength = 256
 let counter = 1
@@ -18,8 +18,13 @@ const Canvas = () => {
 
     const { state } = useContext(BlockchainContext)
     const { account, squares, totalSupply, maxSupply } = state || {}
-    const [currentCoord, setCoord] = useState('.')
 
+    const [ currentCoord, setCoord ] = useState('_')
+    const providerSetCoord = useMemo(() => ({currentCoord, setCoord}), [currentCoord, setCoord])
+    
+    const [ highlightSquares, setHighlightSquares ] = useState(false)
+    const providerSetHighlight = useMemo(() => ({highlightSquares, setHighlightSquares}), [highlightSquares, setHighlightSquares])
+        
     const grid = [];
     for (let row = 0; row < gridLength; row++) {
         grid.push(counter)
@@ -70,7 +75,8 @@ const Canvas = () => {
             })
     
   return (
-    <CoordinateContext.Provider value={{ currentCoord, setCoord }}>
+    <CoordinateContext.Provider value={providerSetCoord}>
+        <HighlightContext.Provider value={providerSetHighlight}>
                 <Row>
                     <Col>
                         {account ? <ToggleOwnedSquares /> : <div />}      
@@ -91,6 +97,7 @@ const Canvas = () => {
                         <SidePanel />
                     </Col>
                 </Row>
+        </HighlightContext.Provider>
     </CoordinateContext.Provider>
     )}
 

--- a/app/src/components/Canvas/coordinateViewer.js
+++ b/app/src/components/Canvas/coordinateViewer.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { CoordinateContext } from '../../context/CoordinateContext'
+import { CoordinateContext } from '../canvasContextProvider'
 
 
 const CoordinateViewer = () => {

--- a/app/src/components/Canvas/gridItem.js
+++ b/app/src/components/Canvas/gridItem.js
@@ -4,7 +4,11 @@ const GridItem = styled.button`
     padding: 0em;
     border: none;
     background: ${props => props.colour};
-    border: ${props => props.selected ? '2px solid' + props.inverseColour : 'none'};
+    border: ${props => 
+        props.highlight ? '2px solid' + props.inverseColour 
+        :        
+        props.selected ? '2px solid' + props.inverseColour
+        : 'none'};
     text-align: center;
     height: 16px;
     width: 16px;

--- a/app/src/components/Canvas/square.js
+++ b/app/src/components/Canvas/square.js
@@ -3,18 +3,19 @@ import $ from 'jquery'
 
 import GridItem from './gridItem'
 import { BlockchainContext, SquareContext } from '../stateProvider'
-import { CoordinateContext } from '../../context/CoordinateContext'
+import { CoordinateContext, HighlightContext } from '../canvasContextProvider'
 import { getSquareColumn, getSquareRow, invertColour, coordToString } from '../../utils/utilityFunctions'
 
 const Square = ({ id }) => {
 
     const { state } = useContext(BlockchainContext)
-    const { account, squares } = state || {}
-    const [ selectedSquare, setSelectedSquare ] = useContext(SquareContext)
+    const { squares, ownedSquares } = state || {}
+    const { selectedSquare, setSelectedSquare } = useContext(SquareContext)
     const { setCoord } = useContext(CoordinateContext)
+    const { highlightSquares } = useContext(HighlightContext)
+
 
     const squareId = parseInt(id.split('-')[1])
-
 
     //Using white as placeholder colours for unclaimed squares, in future we should change that
     //this would require changing invertedColour function to handle RGB conversion too
@@ -23,43 +24,19 @@ const Square = ({ id }) => {
     const squareColour = (squares ? squares[squareId - 1] > -1 ? squares[squareId - 1] : '#ffffff': '#ffffff' )
     const invertedColour = (squares ? squares[squareId - 1] > -1 ? invertColour(squareColour) : '#000000' : '#000000' )
 
-    const hoveredSquareColumn = {
-        'opacity': '0.5',
-    }
+    //Hover CSS states
+    const hoveredSquareColumn = {'opacity': '0.5',}
+    const hoveredSquareRow = {'opacity': '0.5',}
+    const unhoveredSquareColumn = {'opacity': '1',}
+    const unhoveredSquareRow = {'opacity': '1',}
 
-    const hoveredSquareRow = {
-        'opacity': '0.5',
-    }
-
-    const unhoveredSquareColumn = {
-        'opacity': '1',
-    }
-
-    const unhoveredSquareRow = {
-        'opacity': '1',
-    }
-
-    //In future we can use this if we want to change behaviours from users who are logged in vs not
-    //This is instead handled on the Side Panel level now (Not logged in > Cannot claim square)
-    const routeClickEvent = (e) => { account ? handleClick(e) : handleClick(e) }       
-
-    // I have removed the jquery calls here, and replaced them with styled-components props interactions
-    // between square and gridItem
-    const handleClick = (e) => {
-        if (selectedSquare === squareId) {
-            setSelectedSquare(null)
-        }
-        else {
-            setSelectedSquare(squareId)
-        }
-    }
+    const handleClick = (e) => {(selectedSquare === squareId) ? setSelectedSquare(null) : setSelectedSquare(squareId)}
 
     const handleEnter = (e) => {
         e.target.style.opacity = '0.5'
 
         const column = getSquareColumn(squareId)
         const row = getSquareRow(squareId)
-
         for (let columnSquare of column) {
             let nodeId = '#node-' + columnSquare
             $(nodeId).css(hoveredSquareColumn)
@@ -88,17 +65,21 @@ const Square = ({ id }) => {
             $(nodeId).css(unhoveredSquareRow)
         }
 
-        setCoord('.')
+        setCoord('_')
     }
 
+    let squareSelected = selectedSquare === squareId
+    let highlightSquare = (ownedSquares[squareId]>0) && highlightSquares
+    
     return (
         <GridItem
             className='node grid-item'
             id={id}
-            onClick={routeClickEvent}
+            onClick={handleClick}
             onMouseEnter={handleEnter}
             onMouseLeave={handleLeave}
-            selected={ selectedSquare === squareId ? true : false }
+            selected={ squareSelected }
+            highlight= { highlightSquare }
             colour={squareColour}
             inverseColour={invertedColour}
         >

--- a/app/src/components/Canvas/squareHistory.js
+++ b/app/src/components/Canvas/squareHistory.js
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react'
-import { Table } from 'react-bootstrap'
+import React, { useContext, useState } from 'react'
+import { Table, Pagination, PageItem } from 'react-bootstrap'
 
 import { BlockchainContext, SquareContext } from '../stateProvider'
 import EventRow from '../CanvasHistory/eventRow'
@@ -8,18 +8,18 @@ import { TableHead, Head, TableBody, TableRow } from '../SquareManager/tableComp
 const SquareHistory = () => {
     const { state } = useContext(BlockchainContext)
     const { history } = state
-    const [selectedSquare] = useContext(SquareContext)
+    const {selectedSquare} = useContext(SquareContext)
 
     let listSquareEvents = []
-       
+    const [currentPage, setCurrentPage] = useState(1)
+    const eventsPerPage = 6
+    
+
     for (let event of history) {
-        console.log(event.id)
         if (event.id === selectedSquare) {
             listSquareEvents.push(event)
         }    
     }
-
-    console.log(selectedSquare)
 
     let columnTitles = ['Event', 'Colour', 'Date', 'Receipt']
     let headings = columnTitles.map(element => {
@@ -30,24 +30,61 @@ const SquareHistory = () => {
         )
     })
 
-    let squareEventRows = listSquareEvents.map(element => {
+    let squareEventsRows = listSquareEvents.map(element => {
         return(
             <EventRow data={element} key={element.txId} showID={false}/>
         )
     }) 
 
+    const lastEventOnPage = currentPage * eventsPerPage
+    const firstEventOnPage = lastEventOnPage - eventsPerPage
+    const eventsOnPage = squareEventsRows.slice(firstEventOnPage, lastEventOnPage)
+    const totalPages = Math.ceil(squareEventsRows.length/eventsPerPage)
+
+    const pageNumbers = []
+    for (let i = 1; i <= totalPages; i++) {
+        pageNumbers.push(i)
+    }
+
+    const handlePageClick = (page) => {
+        setCurrentPage(page)
+    }
+
+    let pages = pageNumbers.map(page => {
+        return(
+            <PageItem key={page} active={page===currentPage} onClick={() => handlePageClick(page)}>
+                {page}
+            </PageItem>    
+        )
+    })
+
     return (
-        <Table>
-            <TableHead>
-                <TableRow>
-                { headings }
-                </TableRow>
-            </TableHead>
-            <TableBody>
-                { squareEventRows }
-            </TableBody>
-        </Table>
-    )
+        <span>
+            { listSquareEvents.length ? 
+            <div>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            { headings }
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        { eventsOnPage }
+                    </TableBody>
+                </Table>
+                { totalPages > 1 ?
+                    <Pagination>
+                        {pages}
+                    </Pagination>
+                    :
+                    <div></div>
+                }
+            </div>
+            : 
+            
+            <h4><i>This square has no history :(</i></h4>}
+        </span>
+    )    
 }
 
 export default SquareHistory

--- a/app/src/components/Canvas/toggleOwnedSquares.js
+++ b/app/src/components/Canvas/toggleOwnedSquares.js
@@ -1,58 +1,23 @@
 import React, { useContext, useState } from 'react'
 import { Form } from 'react-bootstrap'
-import $ from 'jquery'
 
-import { BlockchainContext, SquareContext } from '../stateProvider'
-import { zip, invertColour } from '../../utils/utilityFunctions'
+import { BlockchainContext } from '../stateProvider'
+import { HighlightContext } from '../canvasContextProvider'
+import { zip } from '../../utils/utilityFunctions'
 
 const ToggleOwnedSquares = () => {
 
     const { state } = useContext(BlockchainContext)
-    const { ownedSquares, squares } = state
+    const { ownedSquares } = state
     const userSquares = zip(ownedSquares)
     const [checked, setChecked] = useState(false)
-    const [selectedSquare] = useContext(SquareContext)
-    const squareColour = (squares[selectedSquare - 1] > -1 ? squares[selectedSquare - 1] : '#ffffff')
-    const invertedColour = (squares[selectedSquare - 1] > -1 ? invertColour(squareColour) : '#000000')
 
-    const chosenSquare = {
-        'border': '2px solid ' + invertedColour,
-    }
-    
-    const highlightedSquare = {
-        'border': '2px solid #FFD700',
-    }
+    const { highlightSquares, setHighlightSquares } = useContext(HighlightContext)
 
-    const unHighlightedSquare = {
-        'border': 'none',
-    }
 
-    const highlightSquares = (e) => {
-        setChecked(e.currentTarget.checked)
-
-        for (let ownedSquare of userSquares) {
-            let nodeId = '#node-' + ownedSquare[0]
-            $(nodeId).css(highlightedSquare)
-        }
-    }
-
-    const unHighlightSquares = (e) => {
-        setChecked(e.currentTarget.checked)
-
-        let selectedSquareString = ''
-        if (selectedSquare) {
-            selectedSquareString = selectedSquare.toString()
-        }
-
-        for (let ownedSquare of userSquares) {
-            let nodeId = '#node-' + ownedSquare[0]
-
-            if (selectedSquareString === ownedSquare[0]) {
-                $(nodeId).css(chosenSquare)
-            } else {
-                $(nodeId).css(unHighlightedSquare)
-            }
-        }
+    const toggleHighlight = (e) => {
+        setChecked(!checked)
+        setHighlightSquares(!highlightSquares)
     }
 
     return (
@@ -62,7 +27,7 @@ const ToggleOwnedSquares = () => {
                 id='toggleOwnedSquares'
                 checked = {checked}
                 value="1"
-                onChange={checked ? unHighlightSquares : highlightSquares}
+                onChange={toggleHighlight}
                 label={checked ?
                         'Hide Owned Squares'
                         :

--- a/app/src/components/CanvasHistory/eventRow.js
+++ b/app/src/components/CanvasHistory/eventRow.js
@@ -19,7 +19,7 @@ const SquareIcon = styled.div`
 const EventRow = ({ data, showID }) => {
 
     const { date, id, colour, topic, txId } = data
-    const [ selectedSquare, setSelectedSquare ] = useContext(SquareContext)
+    const { setSelectedSquare } = useContext(SquareContext)
 
     const handleClick = (e) => {
         setSelectedSquare(id)

--- a/app/src/components/CanvasHistory/eventToast.js
+++ b/app/src/components/CanvasHistory/eventToast.js
@@ -19,7 +19,7 @@ const EventToast = ({ data }) => {
     const [show, setShow] = useState(true)
     const toggleShow = () => setShow(!show)
 
-    const [ selectedSquare, setSelectedSquare ] = useContext(SquareContext)
+    const { setSelectedSquare } = useContext(SquareContext)
 
     const handleClick = (e) => {
         setSelectedSquare(id)

--- a/app/src/components/Header/connectButton.js
+++ b/app/src/components/Header/connectButton.js
@@ -12,7 +12,7 @@ const ConnectButton = () => {
     const [loading, setLoading] = useState(false)
     const [loadingLogout, setLoadingLogout] = useState(false)
     const [showConfirm, setShowConfirm] = useState(false)
-    const [selectedSquare, setSelectedSquare] = useContext(SquareContext)
+    const {selectedSquare, setSelectedSquare} = useContext(SquareContext)
 
     const handleClick = async () => {
 

--- a/app/src/components/SidePanel/sidePanel.js
+++ b/app/src/components/SidePanel/sidePanel.js
@@ -6,7 +6,7 @@ import SquareStats from './squareStats'
 
 const SidePanel = () => {
 
-    const [selectedSquare, setSelectedSquare] = useContext(SquareContext)
+    const {selectedSquare} = useContext(SquareContext)
 
     return (
         <span>

--- a/app/src/components/SidePanel/squareStats.js
+++ b/app/src/components/SidePanel/squareStats.js
@@ -36,7 +36,7 @@ const SquareStats = () => {
 
     const { state } = useContext(BlockchainContext)
     const { account, squares, ownedSquares } = state || {}
-    const [selectedSquare, setSelectedSquare] = useContext(SquareContext)
+    const { selectedSquare, setSelectedSquare } = useContext(SquareContext)
 
     const buttonId = '#node-' + selectedSquare
     const squareColour = (squares[selectedSquare - 1] > -1 ? decimalToHexColour(squares[selectedSquare - 1]) : $(buttonId).css('background-color'))
@@ -88,7 +88,9 @@ const SquareStats = () => {
                     </div>
             }
 
-            <Button onClick={handleShow}>Show Square History</Button>  
+            {account ? <Button onClick={handleShow}>Show Square History</Button> : <div></div>}
+            
+              
             
             <Modal size="lg" show={showHistory} onHide={handleClose}>
                 <Modal.Header closeButton>

--- a/app/src/components/SquareManager/handleSquare.js
+++ b/app/src/components/SquareManager/handleSquare.js
@@ -7,7 +7,7 @@ import { Square, Data, TableRow } from './tableComponents'
 
 const HandleSquare = ({ squareId, squareColour }) => {
 
-    const [ selectedSquare, setSelectedSquare ] = useContext(SquareContext)
+    const { setSelectedSquare } = useContext(SquareContext)
 
     const handleClick = (e) => {
         setSelectedSquare(parseInt(squareId))

--- a/app/src/components/canvasContextProvider.js
+++ b/app/src/components/canvasContextProvider.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const CoordinateContext = React.createContext(null)
+export const HighlightContext = React.createContext(null)
+

--- a/app/src/components/forms/mintForm.js
+++ b/app/src/components/forms/mintForm.js
@@ -39,8 +39,8 @@ const MintForm = () => {
         <BaseForm
             callback={mintSquare}
             message= 'claim square'
-            currentColour='#000000' />
-
+            currentColour='#000000' 
+            key = ''/>
         )
 }
 

--- a/app/src/components/stateProvider.js
+++ b/app/src/components/stateProvider.js
@@ -1,4 +1,4 @@
-import React, { useState, useReducer } from 'react'
+import React, { useState, useReducer, useMemo } from 'react'
 import { blockchainReducer } from '../utils/blockchainUtils'
 
 export const BlockchainContext = React.createContext(null)
@@ -22,10 +22,12 @@ const StateWrapper = ({ children }) => {
     const [state, dispatch] = useReducer(blockchainReducer, initialState)
     
     const [ selectedSquare, setSelectedSquare ] = useState(null)
+    
+    const providerSelectSquare = useMemo(() => ({selectedSquare, setSelectedSquare}), [selectedSquare, setSelectedSquare])
 
     return(
         <BlockchainContext.Provider value={{ state, dispatch }}>
-            <SquareContext.Provider value={[ selectedSquare, setSelectedSquare ]}>
+            <SquareContext.Provider value={providerSelectSquare}>
             {children}
             </SquareContext.Provider>
         </BlockchainContext.Provider>

--- a/app/src/context/CoordinateContext.js
+++ b/app/src/context/CoordinateContext.js
@@ -1,7 +1,0 @@
-import { createContext } from 'react'
-
-const CoordinateContext = createContext(null)
-
-export { CoordinateContext }
-
-


### PR DESCRIPTION
Getting back into Flatland dev after a long break. Some changes in this version:

**Changes to Context**
- Removed the Context folder. Now there's a canvasContext file which has context for coordinates and highlighting owned squares
- Toggle owned squares seems to work more reliably with changing it to context.
- The highlight is now using the inverted colour border instead of the yellow (but can easily be reverted back). Now processes the border in GridItem and removed the jQuery code
- Struggled to remove the coordinate hover jQuery code. Something to look into in the future.

**Changes to Square History**
- Square history is now paginated
- Added use-case if square has no logged history 
- Users not logged in cannot see square history button

**Changes to Forms**
- Forms are now handled in modals.
- Colour picker no longer has open and closed states since the modal can accommodate the element well. Can revert this change.
- When a transaction is processing a toast will appear which will be replaced with either a success/error toast. This toast cannot be manually dismissed.

- Some small bug fixes and refactoring here and there